### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,7 +1,5 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 1aab6f5759f8ab5d35e6cb8589dfce4518f2cc49

**Description:** The pull request modifies the `LinksController.java` file by removing unused imports. Specifically, the imports for `org.springframework.boot.*` and `org.springframework.http.HttpStatus` have been deleted. This change appears to be a cleanup effort to improve code readability and maintainability by eliminating unnecessary dependencies.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`
- **Changes Made:** 
  - Removed the import statement for `org.springframework.boot.*`.
  - Removed the import statement for `org.springframework.http.HttpStatus`.

**Recommendation:** 
1. **Code Quality:** Removing unused imports is a good practice as it reduces clutter and potential confusion for developers. However, ensure that these imports are indeed unused throughout the file. If they are required in other parts of the code, their removal could lead to runtime errors or compilation issues. Double-check the functionality of the `LinksController` class after this change.
2. **Testing:** Run the unit tests and integration tests for the `LinksController` class to confirm that the removal of these imports does not affect the application's behavior.
3. **Documentation:** If this cleanup is part of a broader refactoring effort, document the changes in the project's changelog or commit message to inform other developers about the rationale behind the removal.

**Explanation of vulnerabilities:** 
- **Potential Issue:** While removing unused imports does not directly introduce vulnerabilities, it is important to ensure that the removed imports are not required for any implicit functionality or annotations in the code. For example, if `HttpStatus` was used in exception handling or response management, its removal could lead to unexpected behavior.
- **Correction Suggestion:** If `HttpStatus` or `org.springframework.boot.*` is required elsewhere in the code, reintroduce the necessary imports. For example:
  ```java
  import org.springframework.http.HttpStatus;
  ```
  Ensure that the code is thoroughly reviewed and tested to avoid introducing bugs or breaking existing functionality.

