### PR TITLE
[GFTCodeFixer]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -11,7 +11,7 @@ public class VulnadoApplicationTests {
 
 	@Test
 	public void contextLoads() {
-	}
+        throw new UnsupportedOperationException("Method not implemented");
 
 }
 


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 714e236829d70ec222f79b725792fe972d3ef7c4

**Description:** The pull request modifies the `contextLoads` method in the `VulnadoApplicationTests` class. Previously, the method was empty, but now it throws an `UnsupportedOperationException` with the message "Method not implemented."

**Summary:** 
- **File Modified:** `src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java`
  - **Change:** The `contextLoads` method was updated from an empty implementation to throwing an `UnsupportedOperationException`. 
  - **Code Before:** 
    ```java
    @Test
    public void contextLoads() {
    }
    ```
  - **Code After:** 
    ```java
    @Test
    public void contextLoads() {
        throw new UnsupportedOperationException("Method not implemented");
    }
    ```

**Recommendation:** 
1. **Testing Purpose:** The `contextLoads` method is typically used in Spring Boot applications to verify that the application context loads successfully. Throwing an exception in this method defeats its purpose. Instead, consider implementing a meaningful test or leaving the method empty if no specific test is required.
   - **Suggested Fix:** 
     ```java
     @Test
     public void contextLoads() {
         // Test that the application context loads successfully
     }
     ```
2. **Documentation:** Add comments to explain why the `UnsupportedOperationException` is being thrown, if this is intentional. This will help other developers understand the reasoning behind this change.
3. **Code Quality:** Throwing an exception in a test method without a clear purpose can lead to confusion and may cause unnecessary test failures. Ensure that the change aligns with the overall testing strategy of the project.

**Explanation of vulnerabilities:** 
- **Potential Issue:** Throwing an `UnsupportedOperationException` in a test method could lead to false positives or negatives in test results. If this method is part of a larger test suite, it may cause the suite to fail unnecessarily, which could obscure real issues in the application.
- **Suggested Correction:** If the intention is to indicate that the method is not yet implemented, use annotations like `@Disabled` from JUnit to mark the test as pending implementation. Example:
  ```java
  @Test
  @Disabled("Test not implemented yet")
  public void contextLoads() {
      // Pending implementation
  }
  ```

This approach avoids runtime exceptions and provides a clear indication that the test is not yet implemented.