### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 4a0ea38e96d0091188c858f65dfd85e00f7304d7

**Description:** The pull request modifies the `LinksController.java` file to explicitly define the HTTP method (`GET`) for the `@RequestMapping` annotations. This change improves clarity and ensures that the endpoints are explicitly bound to the GET method, which is a best practice for RESTful APIs.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`
  - Removed unused imports: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable`.
  - Updated the `@RequestMapping` annotations for the `/links` and `/links-v2` endpoints to explicitly specify the HTTP method as `RequestMethod.GET`.
  - No changes were made to the logic of the methods themselves.

**Recommendation:** 
1. **Code Quality:** The removal of unused imports is a good practice as it reduces clutter and improves readability. However, consider using `@GetMapping` instead of `@RequestMapping` with `method = RequestMethod.GET`. `@GetMapping` is a more concise and modern annotation specifically designed for GET requests in Spring Boot.
   - Suggested change:
     ```java
     @GetMapping(value = "/links", produces = "application/json")
     List<String> links(@RequestParam String url) throws IOException {
         return LinkLister.getLinks(url);
     }

     @GetMapping(value = "/links-v2", produces = "application/json")
     List<String> linksV2(@RequestParam String url) throws BadRequest {
         return LinkLister.getLinksV2(url);
     }
     ```
2. **Error Handling:** The `linksV2` method throws a `BadRequest` exception, but there is no indication of how this exception is handled. Consider adding a global exception handler to manage this exception and return a proper HTTP response code (e.g., 400 Bad Request) with a meaningful error message.
3. **Validation:** The `@RequestParam String url` parameter is not validated. This could lead to potential issues if the `url` parameter is empty, malformed, or contains malicious input. Add validation logic to ensure the `url` parameter is safe and meets expected criteria.

**Explanation of vulnerabilities:** 
1. **Potential Security Issue:** The `url` parameter is directly passed to the `LinkLister.getLinks` and `LinkLister.getLinksV2` methods without validation. This could lead to vulnerabilities such as Server-Side Request Forgery (SSRF) if the `LinkLister` class performs HTTP requests based on the `url` parameter. Malicious users could exploit this to make requests to internal services or external endpoints.
   - Suggested fix:
     ```java
     if (!isValidUrl(url)) {
         throw new BadRequest("Invalid URL provided");
     }
     ```
     Implement the `isValidUrl` method to validate the URL format and ensure it adheres to safe patterns.

2. **Error Handling:** The `BadRequest` exception is thrown but not handled. This could result in a generic server error response, which is not user-friendly and may expose unnecessary details about the server. Implement a global exception handler to manage this exception gracefully.

3. **Logging:** Ensure that any exceptions or errors related to the `url` parameter are logged securely without exposing sensitive information. Avoid logging the full URL if it contains sensitive data.

By addressing these recommendations, the code will be more secure, maintainable, and aligned with best practices.