### PR TITLE
[GFTCodeFixer]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -10,7 +10,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class VulnadoApplicationTests {
 
 	@Test
-	public void contextLoads() {
+    public void contextLoads() {
+        throw new UnsupportedOperationException("Method not implemented");
 	}
 
 }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 9221c7d0200b8d916e8e1a69f66faab1166b2037

**Description:** The pull request modifies the `contextLoads` test method in the `VulnadoApplicationTests` class. The method was previously empty, and now it throws an `UnsupportedOperationException` with the message "Method not implemented."

**Summary:** 
- **File Modified:** `src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java`
- **Changes Made:** 
  - The `contextLoads` method was updated from an empty implementation to include a line that throws an `UnsupportedOperationException`. 
  - The indentation of the method was adjusted to align with the new code.

**Recommendation:** 
1. **Purpose Clarification:** The change introduces an exception in a test method, which is unusual for a test case. Typically, test methods are expected to validate functionality rather than explicitly throw exceptions. If the intention is to mark the method as incomplete, consider using annotations like `@Disabled` from JUnit to indicate that the test is not yet implemented. For example:
   ```java
   @Test
   @Disabled("Method not implemented")
   public void contextLoads() {
       // Test logic to be implemented
   }
   ```
   This approach is more descriptive and aligns with testing best practices.

2. **Documentation:** Add comments to explain why the `UnsupportedOperationException` is being thrown. This will help future developers understand the reasoning behind this change.

3. **Code Quality:** Ensure that the exception does not interfere with the test suite execution. If this method is part of a larger test suite, throwing an exception might cause the suite to fail unnecessarily.

**Explanation of vulnerabilities:** 
- **Potential Issue:** Throwing an `UnsupportedOperationException` in a test method could lead to confusion or unintended consequences during automated test runs. If the test suite is integrated into CI/CD pipelines, this exception might cause the pipeline to fail, even though the method is not yet implemented.
- **Suggested Fix:** Replace the exception with a proper annotation (`@Disabled`) or a placeholder comment indicating that the method is a work in progress. This ensures that the test suite remains functional and avoids unnecessary failures.

